### PR TITLE
use `#!/usr/bin/env python` instead of direct path in shebang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ s3:
 	aws s3 cp --sse s3/install-scalyr-agent-2.sh s3://com.scalyr.s3bench/
 	aws s3 cp --sse s3/keepalive.sh s3://com.scalyr.s3bench/
 	aws s3 cp --sse s3/run.sh s3://com.scalyr.s3bench/
-	aws s3 cp --sse s3/s3bench-1.0.6-jar-with-dependencies.jar s3://com.scalyr.s3bench/
+	aws s3 cp --sse s3/s3bench-1.0.8-jar-with-dependencies.jar s3://com.scalyr.s3bench/
 
 all: s3

--- a/provision.sh
+++ b/provision.sh
@@ -45,7 +45,7 @@ cd "$BASE_DIR"
 
 aws s3 cp --sse s3://com.scalyr.s3bench/run.sh .
 aws s3 cp --sse s3://com.scalyr.s3bench/log4j2.xml .
-aws s3 cp --sse s3://com.scalyr.s3bench/s3bench-1.0.6-jar-with-dependencies.jar .
+aws s3 cp --sse s3://com.scalyr.s3bench/s3bench-1.0.8-jar-with-dependencies.jar .
 aws s3 cp --sse s3://com.scalyr.s3bench/keepalive.sh .
 
 chmod u+x $BASE_DIR/run.sh

--- a/s3/keepalive.sh
+++ b/s3/keepalive.sh
@@ -5,8 +5,12 @@ if [ -z "$1" ]; then
    BASE_DIR=$HOME 
 fi
 
+# use "latest" (alphasort) jarfile in case of > 1.  Should only be one, as "provision.sh" copies only one to local machine
+JARFILE=$(ls -1 $BASE_DIR/s3bench-1.0.?-jar-with-dependencies.jar | tail -1)
+
+
 ps -ef | grep "[j]ava.*s3bench" &> /dev/null
 if [ $? -ne 0 ]; then
-    $BASE_DIR/run.sh $BASE_DIR/s3bench-1.0.6-jar-with-dependencies.jar $BASE_DIR/instance.properties &> $BASE_DIR/output-`date "+%Y-%m-%dT%H:%M"`.log&
+    $BASE_DIR/run.sh $JARFILE $BASE_DIR/instance.properties &> $BASE_DIR/output-`date "+%Y-%m-%dT%H:%M"`.log&
 fi
 

--- a/scalyr-aws
+++ b/scalyr-aws
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # AWS utility for Scalyr
 # Copyright 2014 Scalyr Inc.
 


### PR DESCRIPTION
switch shebang to use /usr/bin/env - my osx system has two pythons and /usr/bin/python is the wrong one
